### PR TITLE
Merge v1.0.1 into stable

### DIFF
--- a/GDLogger.csproj
+++ b/GDLogger.csproj
@@ -8,7 +8,7 @@
         <Title>GDLogger</Title>
         <Authors>Carnagion</Authors>
         <Description>A simple logger for Godot projects.</Description>
-        <RepositoryUrl>https://github.com/Carnagion/GDSerializer</RepositoryUrl>
+        <RepositoryUrl>https://github.com/Carnagion/GDLogger</RepositoryUrl>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/GDLogger.csproj
+++ b/GDLogger.csproj
@@ -4,21 +4,14 @@
         <LangVersion>default</LangVersion>
         <Nullable>enable</Nullable>
         <RootNamespace>Godot</RootNamespace>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <PackageVersion>1.0.1</PackageVersion>
         <Title>GDLogger</Title>
         <Authors>Carnagion</Authors>
         <Description>A simple logger for Godot projects.</Description>
         <RepositoryUrl>https://github.com/Carnagion/GDLogger</RepositoryUrl>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-        <DocumentationFile>.\.mono\temp\bin\Debug\GDLogger.xml</DocumentationFile>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)' == 'ExportDebug' ">
-        <DocumentationFile>.\.mono\temp\bin\ExportDebug\GDLogger.xml</DocumentationFile>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)' == 'ExportRelease' ">
-        <DocumentationFile>.\.mono\temp\bin\ExportRelease\GDLogger.xml</DocumentationFile>
     </PropertyGroup>
     <ItemGroup>
         <Content Include=".gitignore" />

--- a/Log.cs
+++ b/Log.cs
@@ -52,6 +52,11 @@ namespace Godot
         }
         
         /// <summary>
+        /// Emitted when an <see cref="Entry"/> has just been written to the log file.
+        /// </summary>
+        public static event Action<Entry>? EntryWritten;
+
+        /// <summary>
         /// Writes the text representation of <paramref name="entry"/> to the log file. Also writes to the console in debug mode.
         /// </summary>
         /// <param name="entry">The <see cref="Entry"/> to write.</param>
@@ -67,6 +72,7 @@ namespace Godot
             }
             Log.entries.Enqueue(entry);
             Log.Flush();
+            Log.EntryWritten?.Invoke(entry);
         }
 
         /// <summary>

--- a/Log.cs
+++ b/Log.cs
@@ -15,21 +15,21 @@ namespace Godot
             AppDomain.CurrentDomain.UnhandledException += Log.OnUnhandledException;
             AppDomain.CurrentDomain.ProcessExit += Log.OnProcessExit;
         }
-
+        
         private const string defaultFilePath = "user://Log.txt";
         
         private const int maxEntryCount = 100;
-
+        
         private const int maxFlushIntervalSeconds = 60;
-
+        
         private const int maxFlushIntervalMessages = 10;
         
         private static readonly Queue<Entry> entries = new(Log.maxEntryCount + 1);
-
+        
         private static readonly File file = new();
         
         private static DateTime lastSynced;
-
+        
         /// <summary>
         /// The file path to which log entries are written.
         /// </summary>
@@ -55,7 +55,7 @@ namespace Godot
         /// Emitted when an <see cref="Entry"/> has just been written to the log file.
         /// </summary>
         public static event Action<Entry>? EntryWritten;
-
+        
         /// <summary>
         /// Writes the text representation of <paramref name="entry"/> to the log file. Also writes to the console in debug mode.
         /// </summary>
@@ -74,7 +74,7 @@ namespace Godot
             Log.Flush();
             Log.EntryWritten?.Invoke(entry);
         }
-
+        
         /// <summary>
         /// Writes <paramref name="message"/> to the log file, encoding it as a notification.
         /// </summary>
@@ -83,7 +83,7 @@ namespace Godot
         {
             Log.Write(new Entry(message, Entry.MessageSeverity.Notification));
         }
-
+        
         /// <summary>
         /// Writes <paramref name="message"/> to the log file, encoding it as a warning.
         /// </summary>
@@ -92,7 +92,7 @@ namespace Godot
         {
             Log.Write(new Entry(message, Entry.MessageSeverity.Warning));
         }
-
+        
         /// <summary>
         /// Writes the text representation of <paramref name="exception"/> to the log file, encoding it as a warning.
         /// </summary>
@@ -101,7 +101,7 @@ namespace Godot
         {
             Log.Write(new Entry(exception.ToString(), Entry.MessageSeverity.Warning));
         }
-
+        
         /// <summary>
         /// Writes <paramref name="message"/> to the log file, encoding it as an error.
         /// </summary>
@@ -110,7 +110,7 @@ namespace Godot
         {
             Log.Write(new Entry(message, Entry.MessageSeverity.Error));
         }
-
+        
         /// <summary>
         /// Writes the text representation of <paramref name="exception"/> to the log file, encoding it as an error.
         /// </summary>
@@ -119,7 +119,7 @@ namespace Godot
         {
             Log.Write(new Entry(exception.ToString(), Entry.MessageSeverity.Error));
         }
-
+        
         private static void Flush(bool force = false)
         {
             DateTime now = DateTime.Now;
@@ -133,7 +133,7 @@ namespace Godot
             Log.file.Flush();
             Log.lastSynced = now;
         }
-
+        
         private static void OnUnhandledException(object source, UnhandledExceptionEventArgs arguments)
         {
             Log.Write(new Entry(arguments.ExceptionObject.ToString(), Entry.MessageSeverity.Error));
@@ -141,7 +141,7 @@ namespace Godot
             {
                 return;
             }
-
+            
             if (Log.file.IsOpen())
             {
                 Log.file.Close();
@@ -149,7 +149,7 @@ namespace Godot
             Log.file.Dispose();
             AppDomain.CurrentDomain.ProcessExit -= Log.OnProcessExit;
         }
-
+        
         private static void OnProcessExit(object source, EventArgs arguments)
         {
             if (Log.file.IsOpen())
@@ -158,7 +158,7 @@ namespace Godot
             }
             Log.file.Dispose();
         }
-
+        
         /// <summary>
         /// Represents a log entry.
         /// </summary>
@@ -183,7 +183,7 @@ namespace Godot
             {
                 get;
             }
-
+            
             /// <summary>
             /// The time when the <see cref="Entry"/> was created.
             /// </summary>
@@ -191,7 +191,7 @@ namespace Godot
             {
                 get;
             }
-
+            
             /// <summary>
             /// The severity level of the <see cref="Entry"/>.
             /// </summary>
@@ -199,7 +199,7 @@ namespace Godot
             {
                 get;
             }
-
+            
             /// <summary>
             /// Returns a <see cref="String"/> that represents the <see cref="Entry"/>.
             /// </summary>
@@ -208,7 +208,7 @@ namespace Godot
             {
                 return $"[{this.Severity}] at {this.Timestamp.Hour}:{this.Timestamp.Minute}:{this.Timestamp.Second}:{this.Timestamp.Millisecond} - {this.Message}";
             }
-
+            
             /// <summary>
             /// Represents a log entry severity.
             /// </summary>

--- a/Log.cs
+++ b/Log.cs
@@ -62,9 +62,7 @@ namespace Godot
         /// <param name="entry">The <see cref="Entry"/> to write.</param>
         public static void Write(Entry entry)
         {
-#if DEBUG
-            GD.Print(entry);
-#endif
+            Log.GodotPrint(entry);
             Log.file.StoreLine(entry.ToString());
             if (Log.entries.Count is Log.maxEntryCount)
             {
@@ -132,6 +130,22 @@ namespace Godot
             Log.entries.Clear();
             Log.file.Flush();
             Log.lastSynced = now;
+        }
+
+        private static void GodotPrint(Entry entry)
+        {
+            switch (entry.Severity)
+            {
+                case Entry.MessageSeverity.Notification:
+                    GD.Print(entry);
+                    break;
+                case Entry.MessageSeverity.Warning:
+                    GD.PushWarning(entry.ToString());
+                    break;
+                case Entry.MessageSeverity.Error:
+                    GD.PushError(entry.ToString());
+                    break;
+            }
         }
         
         private static void OnUnhandledException(object source, UnhandledExceptionEventArgs arguments)

--- a/Log.gd
+++ b/Log.gd
@@ -22,6 +22,9 @@ var _last_synced: int = 0
 ## The file path to which log entries are written.
 var file_path: String setget set_file_path, get_file_path
 
+## Emitted when an entry is written to the log file.
+signal entry_written(entry)
+
 ## Closes the log file if the quit request notification is received.
 func _notification(notif: int) -> void:
 	if notif == MainLoop.NOTIFICATION_WM_QUIT_REQUEST and self._file.is_open():
@@ -47,6 +50,7 @@ func write_entry(entry: Entry) -> void:
 		self._entries.pop_front().free()
 	self._entries.push_back(entry)
 	self._flush()
+	self.emit_signal("entry_written", entry)
 
 ## Writes the message to the log file, encoding it as a notification.
 func write(message: String) -> void:

--- a/Log.gd
+++ b/Log.gd
@@ -114,7 +114,7 @@ class Entry extends Object:
 
 	## Returns a [String] that represents the [Entry].
 	func _to_string() -> String:
-		return "[%s] at %d:%d:%d - %s" % [Entry._severity_to_string(self._severity), self._timestamp["hour"], self._timestamp["minute"], self._timestamp["second"], self._message]
+		return "[%s] at %d:%d:%d - %s" % [Entry._severity_to_string(self.severity), self.timestamp["hour"], self.timestamp["minute"], self.timestamp["second"], self.message]
 
 	static func _severity_to_string(severity: int) -> String:
 		match severity:

--- a/Log.gd
+++ b/Log.gd
@@ -44,7 +44,7 @@ func get_file_path() -> String:
 
 ## Writes the text representation of the [Entry] to the log file. Also writes to the console in debug mode.
 func write_entry(entry: Entry) -> void:
-	print_debug(entry)
+	self._godot_print(entry)
 	self._file.store_line(entry.to_string())
 	if self._entries.size() == self.MAX_ENTRY_COUNT:
 		self._entries.pop_front().free()
@@ -72,6 +72,15 @@ func _flush(force: bool = false) -> void:
 	self._entries.clear()
 	self._file.flush()
 	self._last_synced = now
+
+func _godot_print(entry: Entry) -> void:
+	match entry.severity:
+		Entry.MessageSeverity.NOTIFICATION:
+			print(entry)
+		Entry.MessageSeverity.WARNING:
+			push_warning(entry.to_string())
+		Entry.MessageSeverity.ERROR:
+			push_error(entry.to_string())
 
 ## Represents a log entry.
 class Entry extends Object:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Additionally, the C# version automatically logs unhandled `Exception`s.
   Simply include the following lines in a Godot project's `.csproj` file (either by editing the file manually or letting an IDE install the package):
   ```xml
   <ItemGroup>
-    <PackageReference Include="GDLogger" Version="1.0.0"/>
+    <PackageReference Include="GDLogger" Version="1.0.1"/>
   </ItemGroup>
   ```
   Due to [a bug](https://github.com/godotengine/godot/issues/42271) in Godot, the following lines will also need to be included in the `.csproj` file to properly compile along with NuGet packages:


### PR DESCRIPTION
# Additions
- An `event` (C#) or signal (GDScript) is fired when an entry is logged

# Changes
- `Log.cs` and `Log.gd` no longer print to console only in debug mode
- `Log.cs` and `Log.gd` print to Godot's standard, warning, or error console depending on the severity of the log message